### PR TITLE
Investigate collapse logs display issue

### DIFF
--- a/model.py
+++ b/model.py
@@ -470,8 +470,17 @@ class SeqSetVAE(pl.LightningModule):
             on_epoch=True,
         )
         
+        # Store logged metrics for collapse detector
         if stage == "train":
+            self.logged_metrics = {
+                'train_kl': kl_loss,
+                'train_recon': recon_loss,
+            }
             self.current_step += 1
+            
+        # Expose latent variables for collapse detector
+        if hasattr(self, 'setvae') and hasattr(self.setvae, '_last_z_list'):
+            self._last_z_list = self.setvae._last_z_list
             
         return total_loss
 


### PR DESCRIPTION
Add periodic logging for all posterior collapse metrics and expose latent variables to provide comprehensive monitoring.

Previously, collapse logs only showed variance and active units when specific thresholds were exceeded. This PR ensures all relevant metrics (KL divergence, variance, active units, reconstruction loss) are logged regularly, offering a complete picture of the model's posterior collapse status.

---
<a href="https://cursor.com/background-agent?bcId=bc-1544ecfb-376d-482b-a0f8-b9b4ec0e676b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1544ecfb-376d-482b-a0f8-b9b4ec0e676b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

