### PR TITLE
Resume training from checkpoint without overwriting setvae weights

### DIFF
--- a/model.py
+++ b/model.py
@@ -124,6 +124,7 @@ class SeqSetVAE(pl.LightningModule):
         max_beta: float = 0.1,
         beta_warmup_steps: int = 5000,
         kl_annealing: bool = True,
+        skip_pretrained_on_resume: bool = False,  # 新增参数：是否在恢复时跳过预训练加载
     ):
 
         super().__init__()
@@ -139,7 +140,10 @@ class SeqSetVAE(pl.LightningModule):
             beta,
             lr,
         )
-        if pretrained_ckpt is not None:
+        
+        # 只有在不是从checkpoint恢复时才加载预训练的setvae权重
+        if pretrained_ckpt is not None and not skip_pretrained_on_resume:
+            print(f"🔄 Loading pretrained SetVAE weights from: {pretrained_ckpt}")
             ckpt = torch.load(pretrained_ckpt, map_location='cpu')
             state_dict = ckpt.get("state_dict", ckpt)
             setvae_state = {
@@ -149,6 +153,10 @@ class SeqSetVAE(pl.LightningModule):
             }
             self.setvae.load_state_dict(setvae_state, strict=False)
             del ckpt, state_dict, setvae_state
+        elif pretrained_ckpt is not None and skip_pretrained_on_resume:
+            print(f"⏭️  Skipping pretrained SetVAE loading (resuming from checkpoint)")
+        elif pretrained_ckpt is None:
+            print(f"ℹ️  No pretrained checkpoint provided, using random initialization")
 
         # Freeze X% pretrained parameters
         set_params = list(self.setvae.parameters())

--- a/test_resume_training.py
+++ b/test_resume_training.py
@@ -77,6 +77,12 @@ def test_resume_training():
             print("Error:", result.stderr)
             return False
             
+        # 测试新的skip_pretrained_on_resume功能
+        if "Skipping pretrained SetVAE loading (resuming from checkpoint)" in result.stdout:
+            print("✅ skip_pretrained_on_resume functionality working")
+        else:
+            print("⚠️  skip_pretrained_on_resume functionality not detected in output")
+            
     except subprocess.TimeoutExpired:
         print("⏰ Test timed out (this is normal for a quick test)")
     except Exception as e:

--- a/test_skip_pretrained.py
+++ b/test_skip_pretrained.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+测试skip_pretrained_on_resume功能
+"""
+
+import torch
+import sys
+import os
+
+# 添加当前目录到Python路径
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from model import SeqSetVAE
+import config
+
+def test_skip_pretrained_on_resume():
+    """测试skip_pretrained_on_resume功能"""
+    
+    print("🧪 Testing skip_pretrained_on_resume functionality...")
+    
+    # 测试1: 正常情况（不跳过预训练加载）
+    print("\n1. Testing normal case (skip_pretrained_on_resume=False):")
+    try:
+        model1 = SeqSetVAE(
+            input_dim=config.input_dim,
+            reduced_dim=config.reduced_dim,
+            latent_dim=config.latent_dim,
+            levels=config.levels,
+            heads=config.heads,
+            m=config.m,
+            beta=config.beta,
+            lr=config.lr,
+            num_classes=config.num_classes,
+            ff_dim=config.ff_dim,
+            transformer_heads=config.transformer_heads,
+            transformer_layers=config.transformer_layers,
+            pretrained_ckpt=config.pretrained_ckpt,
+            skip_pretrained_on_resume=False,
+        )
+        print("✅ Normal case passed")
+    except Exception as e:
+        print(f"❌ Normal case failed: {e}")
+        return False
+    
+    # 测试2: 跳过预训练加载的情况
+    print("\n2. Testing skip_pretrained_on_resume=True:")
+    try:
+        model2 = SeqSetVAE(
+            input_dim=config.input_dim,
+            reduced_dim=config.reduced_dim,
+            latent_dim=config.latent_dim,
+            levels=config.levels,
+            heads=config.heads,
+            m=config.m,
+            beta=config.beta,
+            lr=config.lr,
+            num_classes=config.num_classes,
+            ff_dim=config.ff_dim,
+            transformer_heads=config.transformer_heads,
+            transformer_layers=config.transformer_layers,
+            pretrained_ckpt=config.pretrained_ckpt,
+            skip_pretrained_on_resume=True,
+        )
+        print("✅ Skip pretrained case passed")
+    except Exception as e:
+        print(f"❌ Skip pretrained case failed: {e}")
+        return False
+    
+    # 测试3: 没有预训练ckpt的情况
+    print("\n3. Testing no pretrained_ckpt case:")
+    try:
+        model3 = SeqSetVAE(
+            input_dim=config.input_dim,
+            reduced_dim=config.reduced_dim,
+            latent_dim=config.latent_dim,
+            levels=config.levels,
+            heads=config.heads,
+            m=config.m,
+            beta=config.beta,
+            lr=config.lr,
+            num_classes=config.num_classes,
+            ff_dim=config.ff_dim,
+            transformer_heads=config.transformer_heads,
+            transformer_layers=config.transformer_layers,
+            pretrained_ckpt=None,
+            skip_pretrained_on_resume=False,
+        )
+        print("✅ No pretrained ckpt case passed")
+    except Exception as e:
+        print(f"❌ No pretrained ckpt case failed: {e}")
+        return False
+    
+    print("\n🎉 All tests passed!")
+    return True
+
+if __name__ == "__main__":
+    success = test_skip_pretrained_on_resume()
+    
+    if success:
+        print("\n✅ skip_pretrained_on_resume functionality is working correctly!")
+        sys.exit(0)
+    else:
+        print("\n❌ skip_pretrained_on_resume functionality test failed!")
+        sys.exit(1)

--- a/train_optimized.py
+++ b/train_optimized.py
@@ -186,6 +186,7 @@ def main():
         max_beta=config.max_beta,
         beta_warmup_steps=config.beta_warmup_steps,
         kl_annealing=config.kl_annealing,
+        skip_pretrained_on_resume=args.resume_from_checkpoint is not None,  # 如果从checkpoint恢复，跳过预训练加载
     )
     
     # Apply torch.compile if requested


### PR DESCRIPTION
Add `skip_pretrained_on_resume` to prevent pretrained SetVAE weights from overwriting checkpoint state during resume.

---
<a href="https://cursor.com/background-agent?bcId=bc-545fdd40-0412-48fd-8ebc-ecba1a53b41a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-545fdd40-0412-48fd-8ebc-ecba1a53b41a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

