### PR TITLE
Understand pretrained_ckpt and initialization strategies

### DIFF
--- a/train.py
+++ b/train.py
@@ -206,6 +206,14 @@ def main():
             free_bits=model_free_bits,
             transformer_dropout=config.transformer_dropout,
         )
+        # Optional: initialize from checkpoint (weights only)
+        if args.pretrained_ckpt is not None:
+            try:
+                state = load_checkpoint_weights(args.pretrained_ckpt, device='cpu')
+                missing, unexpected = model.load_state_dict(state, strict=False)
+                print(f"🔁 Initialized pretrain model from ckpt (weights only). Missing: {len(missing)}, Unexpected: {len(unexpected)}")
+            except Exception as e:
+                print(f"⚠️  Failed to initialize pretrain model from checkpoint: {e}")
         checkpoint_name = "SeqSetVAE_pretrain"
         monitor_metric = 'val_loss'
         monitor_mode = 'min'


### PR DESCRIPTION
Add support to initialize pretrain model weights from a specified checkpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-881839aa-fba2-4dcd-b3af-5797ca1c64f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-881839aa-fba2-4dcd-b3af-5797ca1c64f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

