### PR TITLE
Debug latent variable not found error

### DIFF
--- a/model.py
+++ b/model.py
@@ -360,7 +360,7 @@ class SeqSetVAEPretrain(pl.LightningModule):
 
             # Encode set -> z
             # Deterministic latent features during pretraining metrics: use mu
-            z_list, _ = self.set_encoder.encode_from_var_val(var, val)
+            _, z_list, _ = self.set_encoder(var, val)
             z_sample, mu, logvar = z_list[-1]
             z_prims.append(mu.squeeze(1))
             all_z_lists.append(z_list)
@@ -907,7 +907,7 @@ class SeqSetVAE(pl.LightningModule):
             pos_list.append(minute_val)
             
             # Deterministic latent features: use posterior mean mu (no sampling)
-            z_list, _ = self.setvae.setvae.encode_from_var_val(var, val)
+            _, z_list, _ = self.setvae.setvae(var, val)
             z_sample, mu, logvar = z_list[-1]
             z_prims.append(mu.squeeze(1))  # use mu as deterministic feature
             


### PR DESCRIPTION
Replace `encode_from_var_val` calls with the standard forward pass to fix attribute errors and ensure latent variables are populated.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb19f10b-5caf-4910-a658-4317bade02d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb19f10b-5caf-4910-a658-4317bade02d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

