### PR TITLE
Fix drawing overlap issue

### DIFF
--- a/model.py
+++ b/model.py
@@ -949,7 +949,7 @@ class SeqSetVAE(pl.LightningModule):
             last_target_list = []
             for idx, s_dict in enumerate(sets):
                 N_t = s_dict["var"].size(1)
-                recon = self.decoder(h_seq[:, idx], N_t, noise_std=0.3)
+                recon = self.decoder(h_seq[:, idx], N_t, noise_std=(0.0 if not self.training else 0.3))
                 if self.setvae.setvae.dim_reducer is not None:
                     reduced = self.setvae.setvae.dim_reducer(s_dict["var"]) 
                 else:


### PR DESCRIPTION
Ensure original and reconstructed data align correctly in UMAP/PCA plots and stabilize reconstruction by fitting transformations only on original data and disabling decoder noise during evaluation.

The previous UMAP/PCA plotting logic fitted the StandardScaler and dimensionality reducer on the combined original and reconstructed data, which could artificially separate the two distributions. This change fits these transformations only on the original data and then applies them to both, ensuring they are projected into the same space. Additionally, decoder noise is now disabled during evaluation to provide stable and deterministic reconstructions for visualization, improving perceived overlap.

---
<a href="https://cursor.com/background-agent?bcId=bc-563d2a58-3222-4e2c-8e3c-ef435fe33d15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-563d2a58-3222-4e2c-8e3c-ef435fe33d15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

