### PR TITLE
Fix logging in validation step

### DIFF
--- a/model.py
+++ b/model.py
@@ -1380,11 +1380,9 @@ class SeqSetVAE(pl.LightningModule):
             if active_ratios:
                 active_units_ratio = torch.stack(active_ratios).mean()
         log_payload = {
-                f"{stage}_loss": total_loss,
                 f"{stage}_recon": recon_loss,
                 f"{stage}_kl": kl_loss,
                 f"{stage}_pred": pred_loss,
-                f"{stage}_class_loss": pred_loss,
                 f"{stage}_beta": current_beta,
                 f"{stage}_recon_weight": recon_weight,
                 f"{stage}_pred_weight": pred_weight,


### PR DESCRIPTION
Remove duplicate `val_loss` logging and redundant `pred_loss` logging to resolve a PyTorch Lightning `MisconfigurationException`.

The `val_loss` was logged both explicitly in `log_dict` and implicitly by PyTorch Lightning from the `validation_step` return value, causing a conflict. Additionally, `pred_loss` was logged under two different keys in the same `log_dict`, which was redundant.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f4eb4f5-f0a1-41bd-8d9e-251ede754dae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f4eb4f5-f0a1-41bd-8d9e-251ede754dae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

