### PR TITLE
排查并修复验证步骤中的日志记录错误

### DIFF
--- a/model.py
+++ b/model.py
@@ -1380,20 +1380,20 @@ class SeqSetVAE(pl.LightningModule):
             if active_ratios:
                 active_units_ratio = torch.stack(active_ratios).mean()
         log_payload = {
-                f"{stage}_pred": pred_loss,
-                f"{stage}_pred_weight": pred_weight,
+                f"{stage}/pred": pred_loss,
+                f"{stage}/pred_weight": pred_weight,
             }
         if not self.classification_only:
             log_payload.update({
-                f"{stage}_recon": recon_loss,
-                f"{stage}_kl": kl_loss,
-                f"{stage}_beta": current_beta,
-                f"{stage}_recon_weight": recon_weight,
+                f"{stage}/recon": recon_loss,
+                f"{stage}/kl": kl_loss,
+                f"{stage}/beta": current_beta,
+                f"{stage}/recon_weight": recon_weight,
             })
         if mean_variance is not None:
-            log_payload[f"{stage}_variance"] = mean_variance
+            log_payload[f"{stage}/variance"] = mean_variance
         if active_units_ratio is not None:
-            log_payload[f"{stage}_active_units"] = active_units_ratio
+            log_payload[f"{stage}/active_units"] = active_units_ratio
         self.log_dict(
             log_payload,
             prog_bar=True,


### PR DESCRIPTION
Fix `MisconfigurationException` by changing logging keys in `_step` to use slash namespaces (e.g., `val/pred` instead of `val_pred`).

The previous logging keys like `val_pred` caused a PyTorch Lightning `MisconfigurationException` because the same key was logged multiple times with different arguments within the `validation_step` (or its internal `_step` call), which is not allowed. Changing to `val/pred` ensures unique logging tags.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fb1f92a-50a2-4224-ab8b-04a5f8567b01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fb1f92a-50a2-4224-ab8b-04a5f8567b01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

