### PR TITLE
Fix duplicate logging in validation step

### DIFF
--- a/model.py
+++ b/model.py
@@ -1380,7 +1380,7 @@ class SeqSetVAE(pl.LightningModule):
             if active_ratios:
                 active_units_ratio = torch.stack(active_ratios).mean()
         log_payload = {
-                f"{stage}/pred": pred_loss,
+                f"{stage}/pred_loss": pred_loss,
                 f"{stage}/pred_weight": pred_weight,
             }
         if not self.classification_only:


### PR DESCRIPTION
Rename `val/pred` log key to `val/pred_loss` to resolve a PyTorch Lightning `MisconfigurationException` caused by duplicate logging.

---
<a href="https://cursor.com/background-agent?bcId=bc-e82fa1c7-a63d-42dd-ad65-743b44d0eb6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e82fa1c7-a63d-42dd-ad65-743b44d0eb6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

