### PR TITLE
Fix duplicate logging in validation step

### DIFF
--- a/model.py
+++ b/model.py
@@ -1397,7 +1397,7 @@ class SeqSetVAE(pl.LightningModule):
         self.log_dict(
             log_payload,
             prog_bar=True,
-            on_step=(stage == "train"),
+            on_step=False,  # Always False for both train and val to avoid conflicts
             on_epoch=True,
         )
         


### PR DESCRIPTION
Fix PyTorch Lightning `MisconfigurationException` by ensuring consistent `on_step` logging arguments for metrics.

The error was caused by logging the same metric key (`val/pred`) with inconsistent `on_step` arguments (True for train, False for val) across different stages. This change sets `on_step=False` consistently, resolving the conflict and logging metrics at the epoch level.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6073d79-496b-4b51-abfa-ddfe2de26013">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d6073d79-496b-4b51-abfa-ddfe2de26013">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

