### PR TITLE
Fix duplicate logging in validation step

### DIFF
--- a/model.py
+++ b/model.py
@@ -471,7 +471,7 @@ class SeqSetVAEPretrain(pl.LightningModule):
                 "scheduler": scheduler,
                 "interval": "epoch",
                 "frequency": 1,
-                "monitor": "val/loss",
+                "monitor": "train_loss",
             },
         }
 
@@ -1376,7 +1376,10 @@ class SeqSetVAE(pl.LightningModule):
         return self._step(batch, "train")
 
     def validation_step(self, batch, batch_idx):
-        return self._step(batch, "val")
+        loss = self._step(batch, "val")
+        # Don't return the loss to avoid automatic logging conflicts
+        # We handle all logging manually in _step
+        return None
 
     def on_validation_epoch_end(self):
         """Only compute validation metrics in finetune mode"""


### PR DESCRIPTION
Prevent duplicate logging in `validation_step` and correct scheduler monitor in `SeqSetVAEPretrain`.

The `validation_step` in `SeqSetVAE` caused a `MisconfigurationException` by returning the loss, which PyTorch Lightning automatically logs, while also manually logging "FT_val_loss". Returning `None` from `validation_step` resolves this conflict. Additionally, the `SeqSetVAEPretrain` class's scheduler was monitoring "val/loss" without a `validation_step`, so it was updated to monitor "train_loss".

---
<a href="https://cursor.com/background-agent?bcId=bc-f457512a-0c4b-4020-bfa1-43d247f342c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f457512a-0c4b-4020-bfa1-43d247f342c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

