### PR TITLE
Fix unexpected keyword argument in SeqSetVAE

### DIFF
--- a/model.py
+++ b/model.py
@@ -512,6 +512,7 @@ class SeqSetVAE(pl.LightningModule):
         focal_alpha = None,
         vae_fusion_method: str = "enhanced_concat",
         estimate_uncertainty: bool = True,
+        transformer_dropout: float = 0.1,
     ):
 
         super().__init__()
@@ -598,7 +599,7 @@ class SeqSetVAE(pl.LightningModule):
             d_model=latent_dim,
             nhead=transformer_heads,
             dim_feedforward=ff_dim,
-            dropout=0.15,  # Increased dropout for better regularization
+            dropout=transformer_dropout,  # Use configurable dropout for better regularization
             activation='gelu',  # Use GELU activation function
             batch_first=True,
             norm_first=True,  # Pre-norm for better training stability


### PR DESCRIPTION
Add `transformer_dropout` parameter to `SeqSetVAE` and apply it to the `TransformerEncoderLayer` to fix a `TypeError` and enable configurable dropout.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fe6dacd-2cf7-4bf5-b808-642d8f446934">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fe6dacd-2cf7-4bf5-b808-642d8f446934">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

