### PR TITLE
Standardize pretrained parameter passing

### DIFF
--- a/train.py
+++ b/train.py
@@ -250,16 +250,7 @@ def main():
         monitor_metric = 'val_auc'
         monitor_mode = 'max'
 
-        # Load pretrained weights if provided
-        if args.pretrained_ckpt is not None:
-            try:
-                state = load_checkpoint_weights(args.pretrained_ckpt, device='cpu')
-                remapped = remap_pretrain_to_finetune_keys(state)
-                missing, unexpected = model.load_state_dict(remapped, strict=False)
-                print(f"🔁 Loaded pretrained weights with remap. Missing: {len(missing)}, Unexpected: {len(unexpected)}")
-            except Exception as e:
-                print(f"⚠️  Failed to load pretrained checkpoint: {e}")
-
+        # Note: Pretrained weights are now loaded automatically in SeqSetVAE constructor
         # Re-initialize classifier head with Xavier for finetune
         model.init_classifier_head_xavier()
 


### PR DESCRIPTION
Pass pretrained checkpoint directly to model constructor and enhance loading logic to fix finetune mode initialization.

Previously, `pretrained_ckpt` was hardcoded to `None` during `SeqSetVAE` initialization in `train.py`, causing a `ValueError` in finetune mode because the model's constructor explicitly requires a checkpoint. Although weights were loaded separately later, the initial validation failed. This PR resolves the issue by passing the correct `pretrained_ckpt` to the constructor and centralizing the intelligent loading and mapping logic within the model, removing redundant code and providing better debugging information.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1dca82d-7ed8-46e0-bdfd-a45652d26a25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1dca82d-7ed8-46e0-bdfd-a45652d26a25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

