### PR TITLE
Standardize pretrained parameter passing

### DIFF
--- a/model.py
+++ b/model.py
@@ -37,14 +37,27 @@ def load_checkpoint_weights(checkpoint_path, device='cpu'):
     # Handle different checkpoint formats
     if isinstance(ckpt, dict) and "state_dict" in ckpt:
         # Full PyTorch Lightning checkpoint
-        state_dict = ckpt["state_dict"]
+        raw_state_dict = ckpt["state_dict"]
         print(f"✅ Found PyTorch Lightning checkpoint with state_dict")
     else:
         # Direct state dict (weights only)
-        state_dict = ckpt
+        raw_state_dict = ckpt
         print(f"✅ Found direct state dict (weights only)")
     
-    return state_dict
+    # Normalize common prefixes to improve compatibility
+    normalized_state = {}
+    for k, v in raw_state_dict.items():
+        new_k = k
+        if new_k.startswith('model.'):
+            new_k = new_k[len('model.'):]
+        if new_k.startswith('module.'):
+            new_k = new_k[len('module.'):]
+        # Some exports may redundantly include 'state_dict.' prefix
+        if new_k.startswith('state_dict.'):
+            new_k = new_k[len('state_dict.'):]
+        normalized_state[new_k] = v
+    
+    return normalized_state
 
 
 ##### SetVAE

--- a/train.py
+++ b/train.py
@@ -113,8 +113,8 @@ def main():
     parser.add_argument("--num_workers", type=int, default=4, help="Number of data loader workers")
     parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility")
     parser.add_argument("--deterministic", action="store_true", help="Enable deterministic training")
-    # Pretrained checkpoint for finetune
-    parser.add_argument("--pretrained_ckpt", type=str, default=None, help="Path to pretrained checkpoint (from pretrain mode)")
+    # Pretrained checkpoint for finetune (with aliases)
+    parser.add_argument("--pretrained_ckpt", "--pretrained", "--ckpt", "--checkpoint", dest="pretrained_ckpt", type=str, default=None, help="Path to pretrained checkpoint (from pretrain mode)")
     # Output root directory
     parser.add_argument("--output_root_dir", type=str, default="/home/sunx/data/aiiih/projects/sunx/projects/TEEMR/PT/outputs", help="Root directory to save logs, checkpoints, and outputs")
     parser.add_argument("--output_dir", type=str, default=None, help="Alias of --output_root_dir; if provided, overrides output_root_dir")
@@ -235,7 +235,7 @@ def main():
             ff_dim=ff_dim,
             transformer_heads=transformer_heads,
             transformer_layers=transformer_layers,
-            pretrained_ckpt=None,  # Will be loaded separately
+            pretrained_ckpt=args.pretrained_ckpt,
             w=config.w,
             free_bits=model_free_bits,
             warmup_beta=config.warmup_beta,
@@ -249,16 +249,6 @@ def main():
         checkpoint_name = "SeqSetVAE_finetune"
         monitor_metric = 'val_auc'
         monitor_mode = 'max'
-
-        # Load pretrained weights if provided
-        if args.pretrained_ckpt is not None:
-            try:
-                state = load_checkpoint_weights(args.pretrained_ckpt, device='cpu')
-                remapped = remap_pretrain_to_finetune_keys(state)
-                missing, unexpected = model.load_state_dict(remapped, strict=False)
-                print(f"🔁 Loaded pretrained weights with remap. Missing: {len(missing)}, Unexpected: {len(unexpected)}")
-            except Exception as e:
-                print(f"⚠️  Failed to load pretrained checkpoint: {e}")
 
         # Re-initialize classifier head with Xavier for finetune
         model.init_classifier_head_xavier()


### PR DESCRIPTION
Pass `pretrained_ckpt` directly to the model and normalize checkpoint keys to fix finetune mode `ValueError` and improve loading robustness.

The `ValueError: ❌ Pretrained checkpoint is required for finetune mode!` occurred because `train.py` was not passing the `--pretrained_ckpt` argument to the `SeqSetVAE` model's constructor, despite attempting to load it manually. This PR resolves the discrepancy by passing the argument directly and also enhances checkpoint loading by stripping common prefixes from state dict keys, making it more resilient to different checkpoint formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-f23c2913-fa5e-4932-880d-d32cea810277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f23c2913-fa5e-4932-880d-d32cea810277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

