### PR TITLE
Fine-tune SeqSetVAE with pretrained checkpoint

### DIFF
--- a/model.py
+++ b/model.py
@@ -227,9 +227,10 @@ class SeqSetVAEPretrain(pl.LightningModule):
     def _relative_time_bucket_embedding(self, minutes: torch.Tensor):
         # minutes: [B, S] (float, minutes)
         B, S = minutes.shape
+        diffs = (minutes[:, 1:] - minutes[:, :-1]).clamp(min=0.0)
         deltas = torch.cat([
             torch.zeros(B, 1, device=minutes.device, dtype=minutes.dtype),
-            torch.diff(minutes, dim=1).clamp(min=0.0)
+            diffs
         ], dim=1)
         log_delta = torch.log1p(deltas)
         log_edges = torch.log1p(self.time_bucket_edges).to(log_delta.device)
@@ -792,9 +793,10 @@ class SeqSetVAE(pl.LightningModule):
     def _relative_time_bucket_embedding(self, minutes: torch.Tensor):
         # minutes: [B, S] (float, minutes)
         B, S = minutes.shape
+        diffs = (minutes[:, 1:] - minutes[:, :-1]).clamp(min=0.0)
         deltas = torch.cat([
             torch.zeros(B, 1, device=minutes.device, dtype=minutes.dtype),
-            torch.diff(minutes, dim=1).clamp(min=0.0)
+            diffs
         ], dim=1)
         log_delta = torch.log1p(deltas)
         log_edges = torch.log1p(self.time_bucket_edges).to(log_delta.device)

--- a/train.py
+++ b/train.py
@@ -235,7 +235,7 @@ def main():
             ff_dim=ff_dim,
             transformer_heads=transformer_heads,
             transformer_layers=transformer_layers,
-            pretrained_ckpt=None,  # Will be loaded separately
+            pretrained_ckpt=args.pretrained_ckpt,
             w=config.w,
             free_bits=model_free_bits,
             warmup_beta=config.warmup_beta,


### PR DESCRIPTION
Pass `args.pretrained_ckpt` to `SeqSetVAE` model during finetuning.

This fixes a `ValueError` where the model incorrectly reported that a pretrained checkpoint was required, as the CLI argument `--pretrained_ckpt` was not being passed to the model constructor.

---
<a href="https://cursor.com/background-agent?bcId=bc-94cc79b9-d7bd-4ce2-9f40-58c49d96e2d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94cc79b9-d7bd-4ce2-9f40-58c49d96e2d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

