### PR TITLE
Address spectral embedding graph warnings

### DIFF
--- a/seqsetvae_poe/_eval_PT.py
+++ b/seqsetvae_poe/_eval_PT.py
@@ -71,6 +71,21 @@ try:
 except Exception:
     umap = None  # type: ignore
 
+# Targeted warning filters to keep logs clean without changing behavior
+import warnings
+warnings.filterwarnings(
+    "ignore",
+    message=r"n_jobs value .* overridden to 1 by setting random_state\. Use no seed for parallelism\.",
+    category=UserWarning,
+    module="umap.umap_",
+)
+warnings.filterwarnings(
+    "ignore",
+    message=r"Graph is not fully connected, spectral embedding may not work as expected\.",
+    category=UserWarning,
+    module="sklearn.manifold._spectral_embedding",
+)
+
 
 # Ensure local imports work even if launched from project root
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -786,7 +801,7 @@ def _plot_overlay_2d(orig: np.ndarray, recon: np.ndarray, out_file: str):
     try:
         if umap is not None:
             reducer = umap.UMAP(
-                n_components=2, random_state=42, n_neighbors=15, min_dist=0.1
+                n_components=2, random_state=42, n_neighbors=15, min_dist=0.1, init="random"
             )
             orig_emb = reducer.fit_transform(orig_s)
             recon_emb = reducer.transform(recon_s)
@@ -1633,7 +1648,7 @@ def _plot_overlay_2d(orig: np.ndarray, recon: np.ndarray, out_file: str):
     # Reduce
     try:
         if umap is not None:
-            reducer = umap.UMAP(n_components=2, random_state=42, n_neighbors=15, min_dist=0.1)
+            reducer = umap.UMAP(n_components=2, random_state=42, n_neighbors=15, min_dist=0.1, init="random")
             orig_emb = reducer.fit_transform(orig_s)
             recon_emb = reducer.transform(recon_s)
         elif PCA is not None:


### PR DESCRIPTION
Suppress UMAP and spectral embedding warnings by setting `init="random"` and adding targeted warning filters.

The UMAP warning about `n_jobs` is due to `random_state` being set, which disables parallelism for determinism. The spectral embedding warning occurs when UMAP's default spectral initialization encounters a disconnected graph. Setting `init="random"` avoids the spectral step, and the filters silence the messages without altering the intended deterministic behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0cbc720-3c56-4244-9de5-f45c557329d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0cbc720-3c56-4244-9de5-f45c557329d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

