### PR TITLE
Investigate masking, cosine, and carryover in recon script

### DIFF
--- a/seqsetvae_poe/random_test_recon.py
+++ b/seqsetvae_poe/random_test_recon.py
@@ -317,6 +317,14 @@ def main():
     print(f"Patient ID: {patient_id}")
     print(f"Set index:  {chosen_set}")
     print(f"#Events:    {len(event_names)}")
+    # Carry-over (mask) summary
+    num_carry = int((mask_np > 0.5).sum())
+    pct_carry = (num_carry / max(1, len(event_names))) * 100.0
+    carried_names = [n for n, m in zip(event_names, mask_np.tolist()) if float(m) > 0.5]
+    if num_carry > 0:
+        print(f"#Carried:   {num_carry} ({pct_carry:.1f}%) -> {', '.join(carried_names)}")
+    else:
+        print("#Carried:   0 (0.0%)")
     print("---------------------------------------------------------------")
     print("原始事件（名称 -> 去归一化前的原始数值）:")
     for name, val_norm, is_mask in zip(event_names, val_np.tolist(), mask_np.tolist()):


### PR DESCRIPTION
Add a summary of carried-over events to `random_test_recon.py` output to explicitly show which events are masked.

---
<a href="https://cursor.com/background-agent?bcId=bc-b04e82b1-ed9b-48ad-af11-06b97fb1d9c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b04e82b1-ed9b-48ad-af11-06b97fb1d9c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

